### PR TITLE
Crouch while in first person (not perfect)

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1,20 +1,22 @@
 local crouched = false
 
 RegisterCommand('crouch', function()
-	if DoesEntityExist(PlayerPedId()) and not IsEntityDead(PlayerPedId()) and not IsPedInAnyVehicle(PlayerPedId(), 1) and not IsPauseMenuActive()  then 
+	if DoesEntityExist(PlayerPedId()) and not IsEntityDead(PlayerPedId()) and not IsPedInAnyVehicle(PlayerPedId(), 1) and not IsPauseMenuActive() then
 		RequestAnimSet("move_ped_crouched")
 		
-		while not HasAnimSetLoaded("move_ped_crouched") do 
+		while not HasAnimSetLoaded("move_ped_crouched") do
 			Citizen.Wait(100)
-		end 
+		end
 
-		if crouched then 
+		if crouched then
 			ResetPedMovementClipset(PlayerPedId(), 0.25)
-			crouched = false 
+			ResetPedStrafeClipset(PlayerPedId())
+			crouched = false
 		else
-			SetPedMovementClipset(PlayerPedId(), "move_ped_crouched", 0.25 )
-			crouched = true 
-		end 
+			SetPedMovementClipset(PlayerPedId(), "move_ped_crouched", 0.25)
+			SetPedStrafeClipset(PlayerPedId(), "move_ped_crouched_strafing")
+			crouched = true
+		end
 
 		RemoveAnimSet("move_ped_crouched")
 	else


### PR DESCRIPTION
Allows players to crouch while in first person mode.
It glitches if player was moving in first person and stopped, hit CTRL twice and it will be okay again.

Maybe some aditional logic would make it better, I leave it for you to test out and decide merge or delete.